### PR TITLE
tweak download instructions for ESOM 1.1 source file

### DIFF
--- a/easybuild/easyconfigs/s/SCGid/SCGid-0.9b0-foss-2021b.eb
+++ b/easybuild/easyconfigs/s/SCGid/SCGid-0.9b0-foss-2021b.eb
@@ -44,6 +44,18 @@ options = {'modulename': False}
 
 local_clams_commit = "e326c34307803b9ea8ffc975ddd9bd05643af931"
 
+local_esom_download_instructions = """You need to manually provide the Databionics ESOM 'source' file.
+Please follow these steps:
+(1): Download the installer for ESOM version %(version)s from
+     https://sourceforge.net/projects/databionic-esom/files/databionic-esom/%(version)s/esom-%(version)s-installer.jar
+(2): Run the installer, and follow through the installation process using the GUI:
+       java -jar esom-%(version)s-installer.jar
+(3): Go to the installation directory where you installed ESOM %(version)s, and create a tarball:
+       tar cvzf esom-%(version)s.tar.gz *
+(4): Move esom-%(version)s.tar.gz to the directory with the SCGid source files (in the EasyBuild sourcepath).
+(5): Re-run EasyBuild to install this SCGid easyconfig file.
+"""
+
 exts_list = [
     ('ClaMS-CLI', '31012020', {
         'source_urls': ['https://github.com/amsesk/ClaMS-CLI-fork/archive'],
@@ -54,17 +66,7 @@ exts_list = [
         'checksums': ['743397fc8308e363f127bd7e5165ac9d769c10305f6e33d9e408db8f343170db'],
     }),
     ('ESOM', '1.1', {
-        'download_instructions': """
-         You need to manually provide Databionics ESOM. Please, follow these steps:
-            (1): Go to https://sourceforge.net/projects/databionic-esom/files/databionic-esom/%(version)s/ and
-                 download "esom-%(version)s-installer.jar"
-            (2): Run the file and follow through the installation process (ensure you have Java
-                 installed to run the file)
-            (3): Open terminal in the folder where you have installed ESOM and create Tarball of
-                 its contents (tar -czvf esom-%(version)s.tar.gz *)
-            (4): Paste the file created (esom-%(version)s.tar.gz) into the same folder where your easyconfig is
-            (5): Re-run the build.
-            """,
+        'download_instructions': local_esom_download_instructions,
         'source_tmpl': 'esom-%(version)s.tar.gz',
         'checksums': [None]
     }),


### PR DESCRIPTION
@ItIsI-Orient for https://github.com/easybuilders/easybuild-easyconfigs/pull/15065

This results in slightly clearer download instructions being printed imho:

```
Download instructions:

You need to manually provide the Databionics ESOM 'source' file.
Please follow these steps:
(1): Download the installer for ESOM version 1.1 from
     https://sourceforge.net/projects/databionic-esom/files/databionic-esom/1.1/esom-1.1-installer.jar
(2): Run the installer, and follow through the installation process using the GUI:
       java -jar esom-1.1-installer.jar
(3): Go to the installation directory where you installed ESOM 1.1, and create a tarball:
       tar cvzf esom-1.1.tar.gz *
(4): Move esom-1.1.tar.gz to the directory with the SCGid source files (in the EasyBuild sourcepath).
(5): Re-run EasyBuild to install this SCGid easyconfig file.
```